### PR TITLE
Backport from h5p master

### DIFF
--- a/classes/framework.php
+++ b/classes/framework.php
@@ -488,6 +488,7 @@ class framework implements \H5PFrameworkInterface {
                 'Unable to parse JSON from the package: %fileName' => 'couldnotparsejsonfromzip',
                 'Could not parse post data.' => 'couldnotparsepostdata',
                 'The mbstring PHP extension is not loaded. H5P needs this to function properly' => 'nombstringexteension',
+                'Assistive Technologies label' => 'assistivetechnologieslabel',
             ];
             // @codingStandardsIgnoreEnd
         }

--- a/lang/en/hvp.php
+++ b/lang/en/hvp.php
@@ -477,3 +477,4 @@ $string['completionpassdesc'] = 'Student must achieve a passing grade to complet
 $string['completionpass_help'] = 'If enabled, this activity is considered complete when the student receives a pass grade (as specified in the Grade section of the H5P activity settings) or higher.';
 $string['gradetopassnotset'] = 'This H5P activity does not yet have a grade to pass set. It may be set in the Grade section of the H5P activity settings.';
 $string['gradetopassmustbeset'] = 'Grade to pass cannot be zero as this H5P activity has its completion method set to require passing grade. Please set a non-zero value.';
+$string['assistivetechnologieslabel'] = 'Assistive Technologies label';


### PR DESCRIPTION
Commit fb62787 contains the following https://github.com/h5p/h5p-php-library/commit/fb6278744c13a16cbc8a6d1a1cd6468ed212d6a2#diff-89117fe225bccb930971b72569064b31f631ae2b7a717300b4cf2845fb14ec6eR4859-R4864 . This will cause a unit test failure in MDL39. 

```
1) core_h5p\api_testcase::test_get_export_info_from_context_id
Unexpected debugging() call detected.
Debugging: String translation cannot be found. Please add a string definition for 'Assistive Technologies label' in the core_h5p component.

/var/www/site/lib/phpunit/classes/advanced_testcase.php:88

To re-run:
 vendor/bin/phpunit "core_h5p\api_testcase" h5p/tests/api_test.php
 ```