### PR TITLE
Wr357498 avoid phpunit error

### DIFF
--- a/classes/file_storage.php
+++ b/classes/file_storage.php
@@ -24,7 +24,12 @@
 
 namespace mod_hvp;
 defined('MOODLE_INTERNAL') || die();
-require_once($CFG->dirroot . '/mod/hvp/library/h5p-file-storage.interface.php');
+
+// To avoid re-declaration error, which can be happened from phpunit, loading from core_component::classloader.
+// This update works for only phpunit, in case we make another bug from this change.
+if (!PHPUNIT_TEST || !interface_exists('\H5PFileStorage')) {
+    require_once($CFG->dirroot . '/mod/hvp/library/h5p-file-storage.interface.php');
+}
 
 /**
  * The mod_hvp file storage class.

--- a/settings.php
+++ b/settings.php
@@ -24,6 +24,11 @@
 // Make sure we are called from an internal Moodle site.
 defined('MOODLE_INTERNAL') || die();
 
+// To avoid phpunit error, do not load anything from this function. It causes conflict with H5P library in Moodle core.
+if (PHPUNIT_TEST) {
+    return;
+}
+
 require_once($CFG->dirroot . '/mod/hvp/lib.php');
 require_once($CFG->dirroot . '/mod/hvp/classes/admin_setting_html.php');
 


### PR DESCRIPTION
We have phpunit errors for latest version of mod/hvp.
PHPUnit tries to load one of the H5P library from Moodle core or mod/hvp, but actually there is no phpunit test for mod/hvp, so it should be only load from Moodle core.
This update is a temporary solution to avoid the phpunit error until Moodle core or mod/hvp have proper solution. (e.g. use namespace for H5P library for each name)