### PR TITLE
Fix checks to match with core handling for allowframeemedding

### DIFF
--- a/classes/output/mobile.php
+++ b/classes/output/mobile.php
@@ -27,7 +27,7 @@ class mobile {
         global $DB, $CFG, $OUTPUT, $USER;
 
         $cmid = $args['cmid'];
-        if (!$CFG->allowframembedding) {
+        if (empty($CFG->allowframembedding) && !core_useragent::is_moodle_app()) {
             $context = \context_system::instance();
             if (has_capability('moodle/site:config', $context)) {
                 $template = 'mod_hvp/iframe_embedding_disabled';


### PR DESCRIPTION
lib/weblib.php:2285 states that it only passes the 'X-Frame-Options: sameorigin' setting if embedding is disabled AND if the user is not loading the page from the app.

```
    // The Moodle app must be allowed to embed content always.
    if (empty($CFG->allowframembedding) && !core_useragent::is_moodle_app()) {
        @header('X-Frame-Options: sameorigin');
    }
```