### PR TITLE
Fix H5P module locking session while saving large content

### DIFF
--- a/classes/view_assets.php
+++ b/classes/view_assets.php
@@ -99,6 +99,16 @@ class view_assets {
     private function getfilteredparameters() {
         global $PAGE;
 
+        // If storing a file the session must be closed before closing the
+        // file with H5P content because file closure might take
+        // substantial time. This will allow other pages to use the session
+        // without waiting on the file operation to finish.
+        //
+        // NOTE: the method framework::messages() must not be called before
+        //       the session is closed.
+        if (empty($this->content["filtered"]))
+            \core\session\manager::write_close();
+
         $safeparameters = $this->core->filterParameters($this->content);
         $decodedparams  = json_decode($safeparameters);
         $hvpoutput      = $PAGE->get_renderer('mod_hvp');


### PR DESCRIPTION
When a user is saving large H5P content (~2Gb) in Moodle it takes about 60 seconds to process changes. However, due to the session locking it is not possible to open another Moodle page in a new browser tab. It ends up with the error "Unable to obtain session lock".

Steps to reproduce the issue in Moodle:

Create a new course or use an existing course in Moodle.
In the course main page add a new activity.
Choose H5P Interactive Content.
Provide some description in Description section.
Inside the editor section choose Upload and upload a large H5P package.
Click "Save and Return to course".
Find the activity that has been created, click Edit -> Edit Settings.
Do not change anything, click "Save and Display". The page will be processing changes for ~90 sec. Go to next step without waiting for it to finish.
Try to open a course page in a new browser tab. It will not open, but start waiting and give the error "Unable to obtain session lock".
Profiling shows that 95% of time is spent inside h5p.classes.php: H5PExport > createExportFile > $zip->Close() call.
The solution for the session locking would be to write_close() the session before finishing zip file. It will allow other pages to use session without waiting on the file operation to finish.

The following scenarios were tested:

Save page with H5P content and try opening another page. With the patched version the new page opened instantly instead of waiting.
Open and save H5P content in two parallel uploads. This worked well too, both pages saved correctly and no unnecessary waiting happened.
Save page with H5P content and try opening the same page in a new tab. In this case the new page waited until the H5P content is saved. It seems to be the case when waiting cannot be avoided since it is trying to access the very content which is being saved.
After adding the fix all tests were conducted with Moodle logging enabled, which did not show any issues. Apache and php error logs were checked for errors as well. Everything worked as it should.