### PR TITLE
Added frontend config for global library backup inclusion

### DIFF
--- a/lang/en/hvp.php
+++ b/lang/en/hvp.php
@@ -64,6 +64,8 @@ $string['removeoldlogentries'] = 'Remove old H5P log entries';
 $string['removeoldmobileauthentries'] = 'Remove old H5P mobile auth entries';
 
 // Admin settings.
+$string['backuplibraries'] = 'Include libraries in backup';
+$string['backuplibraries_help'] = 'Excluding libraries from backup can improve performance during backup. Backups without libraries can only be restored to the same site.';
 $string['displayoptiondownloadnever'] = 'Never';
 $string['displayoptiondownloadalways'] = 'Always';
 $string['displayoptiondownloadpermission'] = 'Only if user has permissions to export H5P';

--- a/settings.php
+++ b/settings.php
@@ -72,6 +72,15 @@ if ($ADMIN->fulltree) {
             1)
     );
 
+    // Include libraries in backup.
+    $settings->add(
+        new admin_setting_configcheckbox('mod_hvp_backup_libraries',
+            get_string('backuplibraries', 'hvp'),
+            get_string('backuplibraries_help', 'hvp'),
+            1
+        )
+    );
+
     $choices = array(
         H5PDisplayOptionBehaviour::NEVER_SHOW => get_string('displayoptiondownloadnever', 'hvp'),
         H5PDisplayOptionBehaviour::ALWAYS_SHOW => get_string('displayoptiondownloadalways', 'hvp'),


### PR DESCRIPTION
https://github.com/h5p/moodle-mod_hvp/blob/bbf3545/backup/moodle2/backup_hvp_activity_task.class.php#L54

This control previously had no frontend exposure. I wanted to refactor it to a plugin level setting, but left it as is, so any forced config in config.php will remain active.