### PR TITLE
Issue #30: Fix asset relative path error

### DIFF
--- a/library_list.php
+++ b/library_list.php
@@ -114,11 +114,8 @@ $settings['libraryList']['listHeaders'] = array(
 );
 
 // Add js.
-$liburl = \mod_hvp\view_assets::getsiteroot() . '/mod/hvp/library/';
-$relpath = '/' . preg_replace('/^[^:]+:\/\/[^\/]+\//', '', $liburl);
-
-hvp_admin_add_generic_css_and_js($PAGE, $relpath, $settings);
-$PAGE->requires->js($relpath . 'js/h5p-library-list.js', true);
+hvp_admin_add_generic_css_and_js($PAGE, $settings);
+$PAGE->requires->js('/mod/hvp/library/js/h5p-library-list.js', true);
 
 // RENDER PAGE OUTPUT.
 

--- a/locallib.php
+++ b/locallib.php
@@ -106,10 +106,6 @@ function hvp_get_core_assets($context) {
     $settings['loadedJs'] = array();
     $settings['loadedCss'] = array();
 
-    // Use relative URL to support both http and https.
-    $liburl = \mod_hvp\view_assets::getsiteroot() . '/mod/hvp/library/';
-    $relpath = '/' . preg_replace('/^[^:]+:\/\/[^\/]+\//', '', $liburl);
-
     // Add core stylesheets.
     foreach (\H5PCore::$styles as $style) {
         $url = generate_css_url('library/' . $style);
@@ -118,7 +114,7 @@ function hvp_get_core_assets($context) {
     }
     // Add core JavaScript.
     foreach (\H5PCore::$scripts as $script) {
-        $scriptpath = $relpath . $script;
+        $scriptpath = '/mod/hvp/library/' . $script;
         $settings['core']['scripts'][] = generate_js_url($scriptpath)->out(false);
         $PAGE->requires->js($scriptpath, true);
     }
@@ -291,14 +287,13 @@ function hvp_add_editor_assets($id = null, $mformid = null) {
  * Add core JS and CSS to page.
  *
  * @param moodle_page $page
- * @param string $relpath
  * @param array|null $settings
  * @throws \coding_exception
  */
-function hvp_admin_add_generic_css_and_js($page, $relpath, $settings = null) {
+function hvp_admin_add_generic_css_and_js($page, $settings = null) {
     // @codingStandardsIgnoreLine
     foreach (\H5PCore::$adminScripts as $script) {
-        $page->requires->js($relpath . $script, true);
+        $page->requires->js('/mod/hvp/library/' . $script, true);
     }
 
     if ($settings === null) {
@@ -314,8 +309,8 @@ function hvp_admin_add_generic_css_and_js($page, $relpath, $settings = null) {
     );
 
     $page->requires->data_for_js('H5PAdminIntegration', $settings, true);
-    $page->requires->css(generate_css_url($relpath . 'styles/h5p.css'));
-    $page->requires->css(generate_css_url($relpath . 'styles/h5p-admin.css'));
+    $page->requires->css(generate_css_url('/mod/hvp/library/styles/h5p.css'));
+    $page->requires->css(generate_css_url('/mod/hvp/library/styles/h5p-admin.css'));
 
     // Add settings.
     $page->requires->data_for_js('h5p', hvp_get_core_settings(\context_system::instance()), true);

--- a/tests/assets_test.php
+++ b/tests/assets_test.php
@@ -1,0 +1,69 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_hvp\tests;
+
+defined('MOODLE_INTERNAL') || die();
+
+global $CFG;
+require_once($CFG->dirroot . '/mod/hvp/locallib.php');
+
+/**
+ * mod_hvp assets tests
+ *
+ * @package    mod_hvp
+ * @author     Matthew Hilton <matthewhilton@catalyst-au.net>
+ * @copyright  2022 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class assets_test extends \advanced_testcase {
+
+    /**
+     * Set up tests.
+     */
+    public function setUp(): void {
+        $this->resetAfterTest();
+        $this->setAdminUser();
+    }
+
+    /**
+     * Tests getting hvp core assets with various wwwroots
+     *
+     * @covers hvp_get_core_assets
+     */
+    public function test_hvp_get_core_assets() {
+        global $CFG;
+
+        $course = $this->getDataGenerator()->create_course();
+        $context = \context_course::instance($course->id);
+
+        $urls = [
+            'https://example.com',
+            'https://example.com/moodle',
+            'https://example.com/moodle/',
+            'http://example.com',
+            'http://example.com/moodle',
+            'http://example.com/moodle/'
+        ];
+
+        // None of these URLS should throw any kind of exception.
+        foreach ($urls as $url) {
+            $CFG->wwwroot = $url;
+            $settings = hvp_get_core_assets($context);
+            $this->assertNotEmpty($settings);
+        }
+    }
+}

--- a/upgrade_content_page.php
+++ b/upgrade_content_page.php
@@ -94,11 +94,9 @@ if (count($versions) < 2) {
     );
 
     // Add JavaScripts.
-    $liburl = \mod_hvp\view_assets::getsiteroot() . '/mod/hvp/library/';
-    $relpath = '/' . preg_replace('/^[^:]+:\/\/[^\/]+\//', '', $liburl);
-    hvp_admin_add_generic_css_and_js($PAGE, $relpath, $settings);
-    $PAGE->requires->js($relpath . 'js/h5p-version.js', true);
-    $PAGE->requires->js($relpath . 'js/h5p-content-upgrade.js', true);
+    hvp_admin_add_generic_css_and_js($PAGE, $settings);
+    $PAGE->requires->js('/mod/hvp/library/js/h5p-version.js', true);
+    $PAGE->requires->js('/mod/hvp/library/js/h5p-content-upgrade.js', true);
     echo $OUTPUT->header();
     echo '<div id="h5p-admin-container">' . get_string('enablejavascript', 'hvp') . '</div>';
 }


### PR DESCRIPTION
Closes #30 
See issue ^ for context

This issue was discovered because it caused an error in another plugin's unit tests. Now that I have added this fix, the other plugin's unit tests are now passing.

**Testing Done**
- Added unit tests passes (would not pass without this change confirming it fixes it)
- Navigated to the touched pages and confirmed no console errors or network 404s / missing files