### PR TITLE
[#36] Add option to toggle proxy

### DIFF
--- a/classes/framework.php
+++ b/classes/framework.php
@@ -66,7 +66,12 @@ class framework implements \H5PFrameworkInterface {
 
             $context = \context_system::instance();
             $root = view_assets::getsiteroot();
-            $url = "{$root}/mod/hvp/proxy_pluginfile.php/{$context->id}/mod_hvp";
+            $url = "{$root}/pluginfile.php/{$context->id}/mod_hvp";
+
+            $useproxy = get_config('mod_hvp', 'enable_pluginfile_proxy');
+            if (!empty($useproxy)) {
+                $url = "{$root}/mod/hvp/proxy_pluginfile.php/{$context->id}/mod_hvp";
+            }
 
             $language = self::get_language();
 

--- a/lang/en/hvp.php
+++ b/lang/en/hvp.php
@@ -99,6 +99,10 @@ $string['contentstatefrequency_help'] = 'In seconds, how often do you wish the u
 $string['enabledlrscontenttypes'] = 'Enable LRS dependent content types';
 $string['enabledlrscontenttypes_help'] = 'Makes it possible to use content types that rely upon a Learning Record Store to function properly, like the Questionnaire content type.';
 
+$string['proxying_settings_header'] = 'Proxy settings';
+$string['enable_pluginfile_proxy'] = 'Enable pluginfile proxy';
+$string['enable_pluginfile_proxy_help'] = 'Pass requests for h5p files through proxy_pluginfile.php, which has the ability to modify the request.';
+
 // Admin menu.
 $string['contenttypecacheheader'] = 'Content Type Cache';
 $string['settings'] = 'H5P Settings';

--- a/settings.php
+++ b/settings.php
@@ -140,6 +140,13 @@ if ($ADMIN->fulltree) {
         $hubinfo
     ));
 
+    // Proxying.
+    $settings->add(new admin_setting_heading('mod_hvp/proxying_settings', get_string('proxying_settings_header', 'hvp'), ''));
+    $settings->add(
+        new admin_setting_configcheckbox('mod_hvp/enable_pluginfile_proxy',
+                get_string('enable_pluginfile_proxy', 'hvp'),
+                get_string('enable_pluginfile_proxy_help', 'hvp'), 1));
+
     // Load js for disable hub confirmation dialog functionality.
     $PAGE->requires->js('/mod/hvp/library/js/jquery.js', true);
     $PAGE->requires->js('/mod/hvp/library/js/h5p-event-dispatcher.js', true);

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022121200;
+$plugin->version   = 2022121201;
 $plugin->requires  = 2013051403;
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';


### PR DESCRIPTION
Closes #36 

**Changes:**
- Added setting to toggle `proxy_pluginfile.php` usage. (it breaks some sites so useful to be able to disable it)

**Testing:**

1. Create mod_hvp in course (can be anything)
2. Open dev tools in network tab
3. Force reload (shift + reload in firefox) to clear cache
4. There should be a file requested with a hash filename e.g. `57e5646cd588d865178b2e6548d978bd3eb13668.js` - Confirm this is requested from `proxy_pluginfile.php`
5. Check the h5p is working
6. In plugin settings, disable proxying
7. Force reload h5p again
8. Confirm the file from before is now coming from `pluginfile.php`
9. Check the h5p is working, it should function exactly the same.