### PR TITLE
38 css proxying not correct when files are in the root of the plugin

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -353,12 +353,16 @@ function hvp_pluginfile($course, $cm, $context, $filearea, $args, $forcedownload
                 return false; // Invalid context.
             }
 
-            $filename = array_pop($args);
-            $filepath = (!$args ? '/' : '/' .implode('/', $args) . '/');
-            $path = $CFG->dirroot . '/mod/hvp' . $filepath . $filename;
-            $cssfile = realpath($path);
+            $relativefilepath = '/' . implode('/', $args);
 
-            css_send_cached_css($cssfile, get_config('mod_hvp', 'version'));
+            // Ensure the path begins with /mod/hvp.
+            if (!str_contains($relativefilepath, '/mod/hvp')) {
+                $relativefilepath = '/mod/hvp' . $relativefilepath;
+            }
+
+            $absolutefilepath = realpath($CFG->dirroot . $relativefilepath);
+
+            css_send_cached_css($absolutefilepath, get_config('mod_hvp', 'version'));
             exit();
     }
 


### PR DESCRIPTION
Closes #38 

- Before: requests to `/mod/hvp/view.css` were getting 404, and in totara showing alert that file is not found
- Now: `/mod/hvp/view.css` queried successfully