### PR TITLE
Fix libraryUrl path to be relative

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -82,7 +82,7 @@ function hvp_get_core_settings($context) {
         'crossoriginCacheBuster' => isset($CFG->mod_hvp_crossoriginCacheBuster) ? $CFG->mod_hvp_crossoriginCacheBuster : null,
         'libraryConfig' => $core->h5pF->getLibraryConfig(),
         'pluginCacheBuster' => '',
-        'libraryUrl' => $basepath . '/lib/javascript.php/' . get_jsrev() . '/library/js'
+        'libraryUrl' => $basepath . '/lib/javascript.php/' . get_jsrev() . '/mod/hvp/library/js'
     );
 
     return $settings;


### PR DESCRIPTION
Upstream code is `'libraryUrl' => $basepath . 'mod/hvp/library/js'`

The previous change had added in the proper files API to access files with jsrev and cache busting, however it had dropped off the `/mod/hvp` part of the file path. In my testing this broke it and files did not load, which lines up with how the `lib/javascript.php` works. So this PR adds back in the prefix, and is tested and working.

Talked to @brendanheywood about it already