### PR TITLE
42: Unit test fail : Property defined was not reset after the test!

### DIFF
--- a/tests/helper_test.php
+++ b/tests/helper_test.php
@@ -41,6 +41,13 @@ class helper_test extends \advanced_testcase {
         $this->generator = $this->getDataGenerator()->get_plugin_generator('mod_hvp');
     }
 
+    /**
+     * Tear down after every test.
+     */
+    protected function tearDown(): void {
+        unset($this->generator);
+    }
+
     public function test_get_library_empty_options() {
         $this->expectException(\moodle_exception::class);
         $this->expectExceptionMessage('No existing libraries were found matching id or title provided.');


### PR DESCRIPTION
#42 

Running unit test results :
**Before :** "There were 12 failures:
Property 'generator' defined in 'mod_hvp\tests\helper_test' was not reset after the test!
Please either find a way to avoid using a class variable or make sure it get's unset in the tearDown method to avoid creating memory leaks."

**After :** OK (12 tests, 26 assertions)
