### PR TITLE
Disable activity header in Moodle 4.0+

### DIFF
--- a/embed.php
+++ b/embed.php
@@ -87,6 +87,11 @@ $PAGE->set_url(new \moodle_url('/mod/hvp/embed.php', array('id' => $id)));
 $PAGE->set_title(format_string($content['title']));
 $PAGE->set_heading($course->fullname);
 
+// Disable activity header on Moodle 4.0+
+if ($CFG->branch >= 400) {
+    $PAGE->activityheader->disable();
+}
+
 // Embed specific page setup.
 $PAGE->add_body_class('h5p-embed');
 $PAGE->set_pagelayout('embedded');


### PR DESCRIPTION
This addition seems to fix issue: #45 . This has been tested on a staging site.

**Before fix:**
![Screenshot from 2023-10-10 11-35-37](https://github.com/catalyst/moodle-mod_hvp/assets/60369890/904a687f-042f-4614-a024-41d4417f7857)

**After fix:** 
![Screenshot from 2023-10-10 11-33-29](https://github.com/catalyst/moodle-mod_hvp/assets/60369890/ac1fc071-cc4b-4043-97a0-584c5693b23d)
