### PR TITLE
Add height if the activity has description

### DIFF
--- a/embed.php
+++ b/embed.php
@@ -87,6 +87,12 @@ $completiondisplay = false;
 if ($cm->completion != 0) {
     $completiondisplay = true;
 }
+
+// If there is intro for the activity, we will add height for the embed.
+if (!empty($content['intro'])) {
+    $completiondisplay = true;
+}
+
 // Configure page.
 $PAGE->set_url(new \moodle_url('/mod/hvp/embed.php', array('id' => $id)));
 $PAGE->set_title(format_string($content['title']));


### PR DESCRIPTION
The embedded h5p frame is not resized correctly when

1. The h5p activity description is set
2. Completion tracking is disabled for the h5p activity

This happen when the h5p is embedded in a forum

The issue does not appear if the H5P has been set with "Completion tracking" (There was a patch to include height of section that contains "completion" ).

If completion tracking is disabled, the height of description is not added to the frame height, hence the content is cropped out.