### PR TITLE
Resolve merge conflicts stable catalyst 400

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -116,6 +116,7 @@ function hvp_get_core_assets($context) {
     // Add core stylesheets.
     foreach (\H5PCore::$styles as $style) {
         $settings['core']['styles'][] = $relpath . $style . $cachebuster;
+        $PAGE->requires->css(new moodle_url($liburl . $style . $cachebuster));
     }
     // Add core JavaScript.
     foreach (\H5PCore::$scripts as $script) {

--- a/locallib.php
+++ b/locallib.php
@@ -116,7 +116,6 @@ function hvp_get_core_assets($context) {
     // Add core stylesheets.
     foreach (\H5PCore::$styles as $style) {
         $settings['core']['styles'][] = $relpath . $style . $cachebuster;
-        $PAGE->requires->css(new moodle_url($liburl . $style . $cachebuster));
     }
     // Add core JavaScript.
     foreach (\H5PCore::$scripts as $script) {

--- a/mod_form.php
+++ b/mod_form.php
@@ -434,15 +434,25 @@ class mod_hvp_mod_form extends moodleform_mod {
     }
 
     public function add_completion_rules() {
+        global $CFG;
+
         $mform   =& $this->_form;
+
+        // Changes for Moodle 4.3 - MDL-78516.
+        if ($CFG->branch < 403) {
+            $suffix = '';
+        } else {
+            $suffix = $this->get_suffix();
+        }
+
         $items   = array();
         $group   = array();
-        $group[] = $mform->createElement('advcheckbox', 'completionpass', null, get_string('completionpass', 'hvp'),
+        $group[] = $mform->createElement('advcheckbox', 'completionpass' . $suffix, null, get_string('completionpass', 'hvp'),
             array('group' => 'cpass'));
-        $mform->disabledIf('completionpass', 'completionusegrade', 'notchecked');
-        $mform->addGroup($group, 'completionpassgroup', get_string('completionpass', 'hvp'), ' &nbsp; ', false);
-        $mform->addHelpButton('completionpassgroup', 'completionpass', 'hvp');
-        $items[] = 'completionpassgroup';
+        $mform->disabledIf('completionpass' . $suffix, 'completionusegrade', 'notchecked');
+        $mform->addGroup($group, 'completionpassgroup' . $suffix, get_string('completionpass', 'hvp'), ' &nbsp; ', false);
+        $mform->addHelpButton('completionpassgroup' . $suffix, 'completionpass', 'hvp');
+        $items[] = 'completionpassgroup' . $suffix;
 
         return $items;
     }

--- a/styles.css
+++ b/styles.css
@@ -118,13 +118,3 @@ body.h5p-embed #maincontent,
 body.h5p-embed #user-notifications {
     display: none;
 }
-/* Import styles to prevent loading after output in locallib */
-
-@import 'library/styles/font-open-sans.css';
-@import 'library/styles/h5p.css';
-@import 'library/styles/h5p-admin.css';
-@import 'library/styles/h5p-confirmation-dialog.css';
-@import 'library/styles/h5p-core-button.css';
-@import 'library/styles/h5p-hub-registration.css';
-@import 'library/styles/h5p-hub-sharing.css';
-@import 'library/styles/h5p-tooltip.css';

--- a/styles.css
+++ b/styles.css
@@ -118,3 +118,13 @@ body.h5p-embed #maincontent,
 body.h5p-embed #user-notifications {
     display: none;
 }
+/* Import styles to prevent loading after output in locallib */
+
+@import 'library/styles/font-open-sans.css';
+@import 'library/styles/h5p.css';
+@import 'library/styles/h5p-admin.css';
+@import 'library/styles/h5p-confirmation-dialog.css';
+@import 'library/styles/h5p-core-button.css';
+@import 'library/styles/h5p-hub-registration.css';
+@import 'library/styles/h5p-hub-sharing.css';
+@import 'library/styles/h5p-tooltip.css';

--- a/version.php
+++ b/version.php
@@ -23,9 +23,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023052600;
+$plugin->version   = 2023122300;
 $plugin->requires  = 2013051403;
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '1.23.1';
+$plugin->release   = '1.26';

--- a/version.php
+++ b/version.php
@@ -23,9 +23,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023122300;
+$plugin->version   = 2023122500;
 $plugin->requires  = 2013051403;
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '1.26';
+$plugin->release   = '1.26.1';


### PR DESCRIPTION
Conflict in `mod_info.php`, kept both changes. 

```php
<<<<<<< HEAD
        // Moodle 4.0 introduces its own pass grade completion rule, so we'll remove it as we have our own.
        // We can switch to the core version if we no longer need to support < 4.0.
        if ($mform->elementExists('completionpassgrade')) {
            $mform->removeElement('completionpassgrade');
        }
=======

        // Changes for Moodle 4.3 - MDL-78516.
        if ($CFG->branch < 403) {
            $suffix = '';
        } else {
            $suffix = $this->get_suffix();
        }

>>>>>>> upstream/stable
```