### PR TITLE
chore: fix namespacing issues in 4.2+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,8 @@
+# .github/workflows/ci.yml
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  ci:
+    uses: catalyst/catalyst-moodle-workflows/.github/workflows/ci.yml@main

--- a/classes/external/log_drain.php
+++ b/classes/external/log_drain.php
@@ -16,6 +16,11 @@
 
 namespace mod_hvp\external;
 
+defined('MOODLE_INTERNAL') || die();
+require_once($CFG->dirroot . '/lib/externallib.php');
+
+// Note - external API has moved to namespaced classes in 4.2+ due to MDL-76583. Including externallib.php file
+// aliases the classes to maintain compatibility with 4.0+.
 use external_api;
 use external_function_parameters;
 use external_multiple_structure;

--- a/classes/external/submit_mobile_finished.php
+++ b/classes/external/submit_mobile_finished.php
@@ -16,7 +16,15 @@
 
 namespace mod_hvp\external;
 
+defined('MOODLE_INTERNAL') || die();
+require_once($CFG->dirroot . '/lib/externallib.php');
+
+// Note - context -> \core\context in 4.2+ due to MDL-74936. However, it is aliased so keep it this way
+// to maintain 4.0+ compatibility.
 use context;
+
+// Note - external API has moved to namespaced classes in 4.2+ due to MDL-76583. Including externallib.php file
+// aliases the classes to maintain compatibility with 4.0+.
 use external_api;
 use external_function_parameters;
 use external_single_structure;

--- a/version.php
+++ b/version.php
@@ -29,3 +29,4 @@ $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->release   = '1.26.1';
+$plugin->supported = [400, 404];


### PR DESCRIPTION
- Fixes externallib and context class namespaces by including necessary lib which has class aliases for older moodle versions (i.e. < 4.2)
    - See https://tracker.moodle.org/browse/MDL-76583 and https://tracker.moodle.org/browse/MDL-74936 for info
- Add ci since it was missing :ghost: 