### PR TITLE
Increase php time limit for library export/import

### DIFF
--- a/export_libraries.php
+++ b/export_libraries.php
@@ -29,6 +29,8 @@ require_once('locallib.php');
 
 admin_externalpage_setup('h5plibraries');
 
+\core_php_time_limit::raise();
+
 $COURSE = $SITE;
 
 $interface = mod_hvp\framework::instance('interface');

--- a/library_list.php
+++ b/library_list.php
@@ -40,6 +40,7 @@ $PAGE->set_title("{$SITE->shortname}: " . get_string('libraries', 'hvp'));
 $uploadform = new \mod_hvp\upload_libraries_form();
 if ($formdata = $uploadform->get_data()) {
     // Handle submitted valid form.
+    \core_php_time_limit::raise();
     $h5pstorage = \mod_hvp\framework::instance('storage');
     $h5pstorage->savePackage(null, null, true);
 }


### PR DESCRIPTION
Exporting/importing libraries can take a while so we need to raise the time limit to infinite or else we hit a 504 gateway error.