### PR TITLE
Update deprecated constant (4.5 compatibility)

### DIFF
--- a/db/messages.php
+++ b/db/messages.php
@@ -34,7 +34,7 @@ $messageproviders = array(
     'confirmation' => array(
         'capability' => 'mod/hvp:emailconfirmsubmission',
         'defaults' => array(
-            'airnotifier' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
+            'airnotifier' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
         ),
     ),
 );

--- a/locallib.php
+++ b/locallib.php
@@ -109,7 +109,7 @@ function hvp_get_core_assets($context) {
     // Do not use $PAGE->requires when viewing via mobile (aka a webservice).
     global $ME;
 
-    if (strpos($ME, 'webservice') == false) {
+    if (strpos($ME ?? '', 'webservice') == false) {
         // Add core stylesheets.
         foreach (\H5PCore::$styles as $style) {
             $url = generate_css_url('library/' . $style);


### PR DESCRIPTION
### TL;DR
`MESSAGE_DEFAULT_LOGGEDIN` and `MESSAGE_DEFAULT_LOGGEDOFF` are deprecated and have been removed in 4.5, preventing the plugin from installing.

These constants have been replaced with `MESSAGE_DEFAULT_ENABLED`.

Additionally, when running unit tests, this message would appear:
```
Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /var/www/workplace/mod/hvp/locallib.php on line 112
```
A null coalescing operator has been added to fix this.

### Links
https://tracker.moodle.org/browse/MDL-67853
https://tracker.moodle.org/browse/MDL-73284
https://github.com/moodle/moodle/blob/505a85eb9ae2db84eff143a282ae79b55205c464/lib/upgrade.txt#L715-L720