### PR TITLE
Fix database schema issue

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -629,7 +629,7 @@ function hvp_upgrade_2023122501() {
 /**
  * Adds mobile render method field
  */
-function hvp_upgrade_2023122502() {
+function hvp_upgrade_20241121001() {
     global $DB;
     $dbman = $DB->get_manager();
 
@@ -672,7 +672,7 @@ function xmldb_hvp_upgrade($oldversion) {
         2020112600,
         2022012001,
         2023122501,
-        2023122502,
+        20241121001,
     ];
 
     foreach ($upgrades as $version) {

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024112100;
+$plugin->version   = 20241121001;
 $plugin->requires  = 2013051403;
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';


### PR DESCRIPTION
+ php admin/cli/check_database_schema.php
-------------------------------------------------------------------------------
hvp
 * column 'mobilerendermethod' is missing
-------------------------------------------------------------------------------

The issue is upgrade script in https://github.com/catalyst/moodle-mod_hvp/pull/67 ran for `2023122502`, but version was dump from `2024091200` to `2024112100`

https://github.com/catalyst/moodle-mod_hvp/pull/67/files#diff-fcb317575e9e6245fdf1590e51a86685b61c2cc9573a9df8034323ccb3ef614fR632

