### PR TITLE
Fix database schema issue - version number

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -629,7 +629,7 @@ function hvp_upgrade_2023122501() {
 /**
  * Adds mobile render method field
  */
-function hvp_upgrade_20241121001() {
+function hvp_upgrade_2024112101() {
     global $DB;
     $dbman = $DB->get_manager();
 
@@ -672,7 +672,7 @@ function xmldb_hvp_upgrade($oldversion) {
         2020112600,
         2022012001,
         2023122501,
-        20241121001,
+        2024112101,
     ];
 
     foreach ($upgrades as $version) {

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 20241121001;
+$plugin->version   = 2024112101;
 $plugin->requires  = 2013051403;
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';


### PR DESCRIPTION
There is an issue in https://github.com/catalyst/moodle-mod_hvp/pull/70 as the version is increase too much (as it's not using decimal point...)