### PR TITLE
Fix bulk update libraries

### DIFF
--- a/classes/task/update_library_task.php
+++ b/classes/task/update_library_task.php
@@ -1,0 +1,99 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_hvp\task;
+
+use core\task\adhoc_task;
+use mod_hvp\framework;
+
+/**
+ * Update H5P library task.
+ *
+ * @package     mod_hvp
+ * @author      Rossco Hellmans <rosscohellmans@catalyst-au.net>
+ * @copyright   2025 Catalyst IT Australia Pty Ltd
+ * @license     http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class update_library_task extends adhoc_task {
+    /**
+     * Get task name
+     *
+     * @return string
+     */
+    public function get_name() {
+        return get_string('updatelibrarytask', 'mod_hvp');
+    }
+
+    /**
+     * Execute task
+     */
+    public function execute() {
+        global $DB;
+
+        $data = $this->get_custom_data();
+        if (empty($data->machinename)) {
+            mtrace('No library set to update, ending task.');
+            return;
+        }
+
+        $machinename = $data->machinename;
+        $librarytitle = $data->librarytitle;
+        $editor = framework::instance('editor');
+        $ajax = $editor->ajax;
+        \H5PCore::createToken('editorajax');
+
+        // Look up content type to ensure it's valid(and to check permissions).
+        $contenttype = $editor->ajaxInterface->getContentTypeCache($machinename);
+        if (!$contenttype) {
+            throw new \moodle_exception('updateinvalidcontenttype', 'mod_hvp', '', $librarytitle);
+        }
+
+        // Override core permission check.
+        $ajax->core->mayUpdateLibraries(true);
+
+        // Retrieve content type from hub endpoint.
+        $endpoint = \H5PHubEndpoints::CONTENT_TYPES . $machinename;
+        $url = \H5PHubEndpoints::createURL($endpoint);
+        $response = $ajax->core->h5pF->fetchExternalData($url, null, true, true);
+        if (!$response) {
+            throw new \moodle_exception('updatedownloadfailed', 'mod_hvp', '', $librarytitle);
+        };
+        $path = $ajax->core->h5pF->getUploadedH5pPath();
+
+        // Validate package.
+        $validator = new \H5PValidator($ajax->core->h5pF, $ajax->core);
+        if (!$validator->isValidPackage(true, true)) {
+            $ajax->storage->removeTemporarilySavedFiles($path);
+            throw new \moodle_exception('updatevalidationfailed', 'mod_hvp', '', $librarytitle);
+        }
+
+        // Save H5P.
+        $storage = new \H5PStorage($ajax->core->h5pF, $ajax->core);
+        $storage->savePackage(null, null, true);
+
+        // Clean up.
+        $ajax->storage->removeTemporarilySavedFiles($path);
+
+        // Refresh content types.
+        // Unfortunately we have to do this or else H5P will blow up.
+        $context = \context_course::instance(SITEID);
+        $_GET['contextId'] = $context->id;
+        $librariescache = $ajax->editor->getLatestGlobalLibrariesData();
+
+        $library = $DB->get_record('hvp_libraries_hub_cache', ['machine_name' => $machinename]);
+        mtrace("Successfully updated {$librarytitle} to version {$library->major_version}.{$library->minor_version}");
+    }
+}

--- a/classes/task/update_library_task.php
+++ b/classes/task/update_library_task.php
@@ -94,6 +94,7 @@ class update_library_task extends adhoc_task {
         $librariescache = $ajax->editor->getLatestGlobalLibrariesData();
 
         $library = $DB->get_record('hvp_libraries_hub_cache', ['machine_name' => $machinename]);
-        mtrace("Successfully updated {$librarytitle} to version {$library->major_version}.{$library->minor_version}");
+        $version = "{$library->major_version}.{$library->minor_version}.{$library->patch_version}";
+        mtrace("Successfully updated {$librarytitle} to version {$version}");
     }
 }

--- a/lang/en/hvp.php
+++ b/lang/en/hvp.php
@@ -680,6 +680,10 @@ $string['mobileoptions'] = 'Mobile app options';
 // Update all libraries.
 $string['updatealllibraries'] = 'Update libraries';
 $string['updatealllibrariesconfirm'] = 'Do you wish to update all libraries (exluding restricted libraries)?';
+$string['updatelibrarytask'] = 'Update library';
+$string['updatedownloadfailed'] = 'Unable to update {$a}: DOWNLOAD_FAILED';
+$string['updateinvalidcontenttype'] = 'Unable to update {$a}: INVALID_CONTENT_TYPE';
+$string['updatevalidationfailed'] = 'Unable to update {$a}: VALIDATION_FAILED';
 
 // Upgrade all content.
 $string['upgradebulkcontent'] = 'Upgrade all content';

--- a/update_libraries.php
+++ b/update_libraries.php
@@ -51,11 +51,10 @@ if ($confirm && confirm_sesskey()) {
     $progressbar->create();
     $progressbar->update(0, 1, 'Finding libraries with updates');
 
+    // Update the hub cache first so we have the latest version info.
     $editor = mod_hvp\framework::instance('editor');
     $ajax = $editor->ajax;
     $token = \H5PCore::createToken('editorajax');
-
-    // Update the hub cache first so we have the latest version info.
     $ajax->core->updateContentTypeCache();
 
     $sql = "SELECT DISTINCT lhc.machine_name, lhc.title, lhc.major_version, lhc.minor_version
@@ -77,50 +76,38 @@ if ($confirm && confirm_sesskey()) {
     $total = count($libraries);
     $counter = 0;
 
+    $queuedlibraries = [];
+
     foreach ($libraries as $library) {
-        $progressbar->update($counter, $total, "Updating {$library->title}");
+        $machinename = $library->machine_name;
+        $librarytitle = $library->title;
+
+        $progressbar->update($counter, $total, "Creating update task for {$librarytitle}");
         $counter++;
 
-        $machinename = $library->machine_name;
+        $updatelibrarytask = new mod_hvp\task\update_library_task();
+        $updatelibrarytask->set_custom_data([
+            'machinename' => $machinename,
+            'librarytitle' => $librarytitle,
+        ]);
+        \core\task\manager::queue_adhoc_task($updatelibrarytask, true);
 
-        // Look up content type to ensure it's valid(and to check permissions).
-        $contenttype = $editor->ajaxInterface->getContentTypeCache($machinename);
-        if (!$contenttype) {
-            echo $OUTPUT->notification("Unable to update {$library->title}: INVALID_CONTENT_TYPE", 'error');
-            break;
-        }
-
-        // Override core permission check.
-        $ajax->core->mayUpdateLibraries(true);
-
-        // Retrieve content type from hub endpoint.
-        $endpoint = H5PHubEndpoints::CONTENT_TYPES . $machinename;
-        $url = H5PHubEndpoints::createURL($endpoint);
-        $response = $ajax->core->h5pF->fetchExternalData($url, null, true, true);
-        if (!$response) {
-            echo $OUTPUT->notification("Unable to update {$library->title}: DOWNLOAD_FAILED", 'error');
-            break;
-        };
-        $path = $ajax->core->h5pF->getUploadedH5pPath();
-
-        // Validate package.
-        $validator = new H5PValidator($ajax->core->h5pF, $ajax->core);
-        if (!$validator->isValidPackage(true, true)) {
-            $ajax->storage->removeTemporarilySavedFiles($path);
-            echo $OUTPUT->notification("Unable to update {$library->title}: VALIDATION_FAILED", 'error');
-            break;
-        }
-
-        // Save H5P.
-        $storage = new H5PStorage($ajax->core->h5pF, $ajax->core);
-        $storage->savePackage(null, null, true);
-
-        // Clean up.
-        $ajax->storage->removeTemporarilySavedFiles($path);
+        $version = "{$library->major_version}.{$library->minor_version}";
+        $queuedlibraries[$librarytitle] = $version;
     }
 
-    // Refresh content types.
-    $librariescache = $ajax->editor->getLatestGlobalLibrariesData();
+    if (!empty($queuedlibraries)) {
+        $message = 'The following libraries have been queued for updating:';
+        $message .= html_writer::start_tag('ul');
+        foreach ($queuedlibraries as $librarytitle => $version) {
+            $message .= html_writer::tag('li', "{$librarytitle} ({$version})");
+        }
+        $message .= html_writer::end_tag('ul');
+    } else {
+        $message = 'No libraries have been queued for updating.';
+    }
+
+    \core\notification::add($message, \core\notification::SUCCESS);
 
     $progressbar->update(1, 1, get_string('completed'));
     echo $OUTPUT->single_button($returnurl, get_string('upgradereturn', 'hvp'));

--- a/update_libraries.php
+++ b/update_libraries.php
@@ -64,7 +64,7 @@ if ($confirm && confirm_sesskey()) {
                 ON lhc.machine_name = l.machine_name
              WHERE l.restricted = ?";
     $libraries = $DB->get_records_sql($sql, [0]);
-    $libraries = array_filter($libraries, function($library) {
+    $libraries = array_filter($libraries, function ($library) {
         global $DB;
         // Find local library with same major + minor.
         return !$DB->record_exists('hvp_libraries', [
@@ -96,12 +96,12 @@ if ($confirm && confirm_sesskey()) {
         // Retrieve content type from hub endpoint.
         $endpoint = H5PHubEndpoints::CONTENT_TYPES . $machinename;
         $url = H5PHubEndpoints::createURL($endpoint);
-        $path = $ajax->core->h5pF->getUploadedH5pPath();
-        $response = $ajax->core->h5pF->fetchExternalData($url, null, true, empty($path) ? true : $path);
+        $response = $ajax->core->h5pF->fetchExternalData($url, null, true, true);
         if (!$response) {
             echo $OUTPUT->notification("Unable to update {$library->title}: DOWNLOAD_FAILED", 'error');
             break;
         };
+        $path = $ajax->core->h5pF->getUploadedH5pPath();
 
         // Validate package.
         $validator = new H5PValidator($ajax->core->h5pF, $ajax->core);

--- a/update_libraries.php
+++ b/update_libraries.php
@@ -57,7 +57,7 @@ if ($confirm && confirm_sesskey()) {
     $token = \H5PCore::createToken('editorajax');
     $ajax->core->updateContentTypeCache();
 
-    $sql = "SELECT DISTINCT lhc.machine_name, lhc.title, lhc.major_version, lhc.minor_version
+    $sql = "SELECT DISTINCT lhc.machine_name, lhc.title, lhc.major_version, lhc.minor_version, lhc.patch_version
               FROM {hvp_libraries_hub_cache} lhc
               JOIN {hvp_libraries} l
                 ON lhc.machine_name = l.machine_name
@@ -70,6 +70,7 @@ if ($confirm && confirm_sesskey()) {
             'machine_name' => $library->machine_name,
             'major_version' => $library->major_version,
             'minor_version' => $library->minor_version,
+            'patch_version' => $library->patch_version,
         ]);
     });
 
@@ -92,7 +93,7 @@ if ($confirm && confirm_sesskey()) {
         ]);
         \core\task\manager::queue_adhoc_task($updatelibrarytask, true);
 
-        $version = "{$library->major_version}.{$library->minor_version}";
+        $version = "{$library->major_version}.{$library->minor_version}.{$library->patch_version}";
         $queuedlibraries[$librarytitle] = $version;
     }
 


### PR DESCRIPTION
This makes three changes:
1. There was an issue where `fetchExternalData` needs to be called first passing `true` for the `$stream` param before the download path is set. We can then get the path that was used after with `getUploadedH5pPath`, instead of the other way around that we had before. https://github.com/catalyst/moodle-mod_hvp/commit/d4d2400caa25175c876266d42ad3b8f8d09eade7
2. I found some libraries were not being curled within the 5 minute timeout set, I even tried a much longer timeout and still no luck. Eventually when I came back to the issue a few weeks later it seemed to be fine, so I suspect there might have been something on the H5P hub end. To handle this better I have moved the updating to adhoc tasks which will be spawned from `update_libraries.php` for each library that needs updating. This way any problematic libraries will not block other libraries from updating and can be retried later. https://github.com/catalyst/moodle-mod_hvp/pull/78/commits/5916cb91b9fbc8d6881d0934d55cba173cb1eda1
3. We used to only check the major and minor version (x.x) when checking which libraries need updating. We want to also check the patch version (x.x.x) to get patch version updates, instead of just updating when there is a new minor version. https://github.com/catalyst/moodle-mod_hvp/pull/78/commits/3581398c1119bc7702c3a79f6894992f64da69d3