### PR TITLE
feat: theme style injection

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -227,6 +227,10 @@ function hvp_add_editor_assets($id = null, $mformid = null) {
         }
     }
 
+    // Apply any theme styling overrides.
+    $renderer = $PAGE->get_renderer('mod_hvp');
+    $renderer->hvp_alter_editor_styles($assets['css']);
+
     // Add JavaScript with library framework integration (editor part).
     $PAGE->requires->js('/mod/hvp/editor/scripts/h5peditor-editor.js', true);
     $PAGE->requires->js('/mod/hvp/editor/scripts/h5peditor-init.js', true);

--- a/renderer.php
+++ b/renderer.php
@@ -44,6 +44,15 @@ class mod_hvp_renderer extends plugin_renderer_base {
     }
 
     /**
+     * Alter which stylesheets are loaded for the H5P editor. This is useful for adding
+     * your own custom styles or replacing existing ones for the H5P editor.
+     *
+     * @param array $styles list of stylesheets that will be loaded
+     */
+    public function hvp_alter_editor_styles(&$styles) {
+    }
+
+    /**
      * Alter which scripts are loaded for H5P. Useful for adding your
      * own custom scripts or replacing existing ones.
      *


### PR DESCRIPTION
This adds a new hook to allow themes to inject css styling when the H5P editor opens.

There is an existing hook which is `hvp_alter_styles`, however this hook injects the styling when a library is loaded, meaning styling won't be applied until a library is selected and the styling will be applied whenever a library is loaded. This new hook will inject the styling earlier and will only inject it for the H5P editor and not when viewing a H5P activity.