### PR TITLE
fix: check perms before installing library during restore

### DIFF
--- a/backup/moodle2/restore_hvp_stepslib.php
+++ b/backup/moodle2/restore_hvp_stepslib.php
@@ -202,6 +202,24 @@ class restore_hvp_libraries_structure_step extends restore_activity_structure_st
 
         $libraryid = self::get_library_id($data);
         if (!$libraryid) {
+            // If this library is not installed, ensure that the user has
+            // permission to install it before proceeding.
+            $params = ['machine_name' => $data->machine_name];
+            if (!$DB->record_exists('hvp_libraries', $params)) {
+                $systemctx = \core\context\system::instance();
+                $caninstall = has_capability('mod/hvp:updatelibraries', $systemctx);
+
+                $librarycache = $DB->get_record('hvp_libraries_hub_cache', $params, 'id, is_recommended');
+                if ($librarycache && $librarycache->is_recommended) {
+                    $coursectx = \core\context\course::instance($this->get_courseid());
+                    $caninstall = $caninstall || has_capability('mod/hvp:installrecommendedh5plibraries', $coursectx);
+                }
+
+                if (!$caninstall) {
+                    throw new \core\exception\moodle_exception('restoreinstalldenied', 'hvp', '', $data->title);
+                }
+            }
+
             // There is no updating of libraries. If an older patch version exists
             // on the site that one will be used instead of the new one in the backup.
             // This is due to the default behavior when files are restored in Moodle.

--- a/lang/en/hvp.php
+++ b/lang/en/hvp.php
@@ -694,3 +694,6 @@ $string['upgradebulkdone'] = 'You have successfully upgraded {$a->count} content
 // Export libraries.
 $string['exportlibraries'] = 'Export libraries';
 $string['exportlibrarieserror'] = 'An error occured while export the libraries.';
+
+// Restore H5P library.
+$string['restoreinstalldenied'] = 'You do not have permission to install missing content type \'{$a}\'. Please contact your site administrator.';

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024120900;
+$plugin->version   = 2024120901;
 $plugin->requires  = 2022112800; // 4.1.0
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';


### PR DESCRIPTION
**Problem:**
Perms are not checked when a user tries to restore a H5P activity with a library that is not installed on the site. This means users could bypass the permissions by backing up the activity in a different site with the library and then restoring it into another site without the library.

**Solution:**
Ideally it would be nice to just skip the activity and leave a message for the user doing the restore. Unfortunately doing this at a point we can is too late, leading to issues with restoring contexts, sections, files, etc. due to the activity being now missing. Alternative is to restore the activity but not the library, meaning when going to the activity it will error due to the library being missing, this may be confusing to the user and may be missed by the user if they do not check.

The most simplest way is to throw an exception with the exact reason why the restore is not possible. The user can then exclude that activity, ask the required people to install that library, etc.

The logic with the `is_recommended` stuff is taken from here: https://github.com/h5p/h5p-editor-php-library/blob/80b3b281ee9d064b563f242e8ee7a0026b5bf205/h5peditor.class.php#L526

**Testing:**
- Have two sites, one with a library installed, and another without that library
- Go to the site with the library installed
- Create a H5P activity using that library
- Backup that activity
- Go to the site without that library installed
- Be logged in as a user you can restore the activity but does not have the capability to install new content types
- Try to restore the backup
- Expected outcome is for the restore to error stating "You do not have permission to install missing content type xyz. Contact the administrator of your site."