### PR TITLE
fix: make restore changes Moodle 4.1 and PHP 7.4 compatible

### DIFF
--- a/backup/moodle2/restore_hvp_stepslib.php
+++ b/backup/moodle2/restore_hvp_stepslib.php
@@ -214,9 +214,9 @@ class restore_hvp_libraries_structure_step extends restore_activity_structure_st
                 // infinate loop, see MDL-81511. So we throw an exception if this is not an adhoc task run,
                 // otherwise log and proceed with a -1 library id.
                 if (!$SCRIPT || strpos($SCRIPT, 'admin/cli/adhoc_task.php') === false) {
-                    throw new \core\exception\moodle_exception('restoreinstalldenied', 'hvp', '', $data->title);
+                    throw new moodle_exception('restoreinstalldenied', 'hvp', '', $data->title);
                 }
-                $this->log('skipping h5p library install', backup::LOG_WARNING, display: true);
+                $this->log('skipping h5p library install', backup::LOG_WARNING, null, null, true);
                 $message = get_string('restoreinstalldenied_adhoc', 'hvp', $data->title);
                 mtrace($message);
                 $libraryid = -1;
@@ -398,13 +398,13 @@ class restore_hvp_libraries_structure_step extends restore_activity_structure_st
     private function can_install(string $machinename): bool {
         global $DB;
 
-        $systemctx = \core\context\system::instance();
+        $systemctx = context_system::instance();
         $caninstall = has_capability('mod/hvp:updatelibraries', $systemctx);
 
         $params = ['machine_name' => $machinename];
         $librarycache = $DB->get_record('hvp_libraries_hub_cache', $params, 'id, is_recommended');
-        if ($librarycache?->is_recommended) {
-            $coursectx = \core\context\course::instance($this->get_courseid());
+        if ($librarycache && $librarycache->is_recommended) {
+            $coursectx = context_course::instance($this->get_courseid());
             $caninstall = $caninstall || has_capability('mod/hvp:installrecommendedh5plibraries', $coursectx);
         }
 


### PR DESCRIPTION
The previous changes we made in https://github.com/catalyst/moodle-mod_hvp/commit/0363680b205df226039845aae725dff8a0b9c780 were not Moodle 4.1 and PHP 7.4 compatible. Because we have clients still on those we need to ensure this remains compatible.

The namespace changes are fine to be 4.1 compatible, 4.5+ has the old classes loading the new classes, so no issue with that.