### PR TITLE
fix: properly handle error messages from curl handler and URL blockers

### DIFF
--- a/classes/framework.php
+++ b/classes/framework.php
@@ -256,7 +256,7 @@ class framework implements \H5PFrameworkInterface {
 
         $errorno = $curl->get_errno();
         // Error handling.
-        if ($errorno) {
+        if ($errorno || !empty($curl->error)) {
             if ($alldata) {
                 $response = null;
             } else {


### PR DESCRIPTION
Prevents infinite loops in upgrade where errno is 0 during registration, except the error message is a block message from core URL blocking or similar.