### PR TITLE
Fix bulk library update and export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,5 @@ jobs:
       disable_mustache: true
       disable_phpdoc: true
       disable_phplint: true
-      disable_phpcpd: true
       disable_phpcs: true
       disable_grunt: true

--- a/classes/file_storage.php
+++ b/classes/file_storage.php
@@ -713,6 +713,11 @@ class file_storage implements \H5PFileStorage {
         if ($file) {
             $file->delete();
         }
+
+        // Remove the archive zip if it exists.
+        if ($file = $fs->get_file($contextid, 'mod_hvp', 'library_archives', $itemid, $filepath, 'lib-export.zip')) {
+            $file->delete();
+        }
     }
 
     /**

--- a/classes/task/update_library_task.php
+++ b/classes/task/update_library_task.php
@@ -75,7 +75,9 @@ class update_library_task extends adhoc_task {
 
         // Validate package.
         $validator = new \H5PValidator($ajax->core->h5pF, $ajax->core);
-        if (!$validator->isValidPackage(true, true)) {
+        // Do not use update only, some library packages are missing required libraries and we don't
+        // want to block the update if that required library is already installed.
+        if (!$validator->isValidPackage(true)) {
             $ajax->storage->removeTemporarilySavedFiles($path);
             throw new \moodle_exception('updatevalidationfailed', 'mod_hvp', '', $librarytitle);
         }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1,4 +1,5 @@
 <?php
+
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
@@ -643,6 +644,83 @@ function hvp_upgrade_2024112101() {
     }
 }
 
+/**
+ * Re-creates the library lib-export.zip archive file for libraries that have been bulk updated.
+ */
+function hvp_upgrade_2024120903() {
+    global $DB;
+
+    $core = \mod_hvp\framework::instance();
+    $hubon = $core->h5pF->getOption('hub_is_enabled', true);
+    if (!$hubon) {
+        // Hub is not enabled, libraries cannot be automatically updated.
+        return;
+    }
+
+    // Update the hub cache first so we have the latest info.
+    $editor = mod_hvp\framework::instance('editor');
+    $ajax = $editor->ajax;
+    $token = \H5PCore::createToken('editorajax');
+    $ajax->core->updateContentTypeCache();
+
+    // Grab all libraries that have had their library.json modified after lib-export.zip was created.
+    $sql = 'SELECT f.filepath
+              FROM {files} f
+              JOIN {files} fa ON fa.filepath = f.filepath AND fa.filename = :archivefilename
+             WHERE f.component = :component
+               AND f.filearea = :filearea
+               AND f.filename = :filename
+               AND f.itemid = 0
+               AND (f.timemodified - fa.timemodified) > :timebuffer';
+    $params = [
+        'archivefilename' => 'lib-export.zip',
+        'filename' => 'library.json',
+        'component' => 'mod_hvp',
+        'filearea' => 'libraries',
+        // Set time buffer to 3 days to be safe, since we don't want to be too agressive,
+        // any that do need to be updated that fit < 3 days can be manually fixed.
+        'timebuffer' => DAYSECS * 3,
+    ];
+
+    $librarypaths = $DB->get_records_sql($sql, $params);
+    foreach ($librarypaths as $librarypath) {
+        $filepath = trim($librarypath->filepath, '/');
+        $versionpos = strrpos($filepath, '-');
+        if ($versionpos !== false) {
+            // Separate machine name and version from filepath. Filepath is in the format /machinename-version/.
+            $machinename = substr($filepath, 0, $versionpos);
+            $version = substr($filepath, $versionpos + 1);
+            $versionparts = explode('.', $version);
+
+            if (!$DB->record_exists('hvp_libraries_hub_cache', ['machine_name' => $machinename])) {
+                // No matching library found in cache, most likely a util library, continue to next.
+                continue;
+            }
+
+            // Grab the library record.
+            $params = [
+                'machine_name' => $machinename,
+                'major_version' => $versionparts[0],
+                'minor_version' => $versionparts[1],
+            ];
+            $library = $DB->get_record('hvp_libraries', $params);
+
+            if ($library && $library->patch_version > 0) {
+                // Matching library found and has a patch version greater than 0.
+                // Reset the patch_version to 0 and create an update library task to force the library to re-save all files.
+                $library->patch_version = 0;
+                $DB->update_record('hvp_libraries', $library);
+
+                $updatelibrarytask = new mod_hvp\task\update_library_task();
+                $updatelibrarytask->set_custom_data([
+                    'machinename' => $machinename,
+                    'librarytitle' => $library->title,
+                ]);
+                \core\task\manager::queue_adhoc_task($updatelibrarytask, true);
+            }
+        }
+    }
+}
 
 /**
  * Hvp module upgrade function.
@@ -673,6 +751,7 @@ function xmldb_hvp_upgrade($oldversion) {
         2022012001,
         2023122501,
         2024112101,
+        2024120903,
     ];
 
     foreach ($upgrades as $version) {

--- a/export_libraries.php
+++ b/export_libraries.php
@@ -46,6 +46,22 @@ $exportedlibraries = [];
 foreach ($libraries as $versions) {
     try {
         // We only want to export the latest version.
+        // H5P sorts libraries by title before version, this is normally fine but in some cases a
+        // library may have a beta version with (beta) in the library title. This naming then throws
+        // off the ordering, so we need to sort the array by version to ensure we get the latest version.
+        usort($versions, function ($a, $b) {
+            if ($a->major_version === $b->major_version) {
+                // Major version is the same, sort by minor version.
+                if ($a->minor_version === $b->minor_version) {
+                    // Minor version is also the same, sort by patch version.
+                    return $a->patch_version <=> $b->patch_version;
+                }
+                return $a->minor_version <=> $b->minor_version;
+            }
+            // Major version is different, sort by major version.
+            return $a->major_version <=> $b->major_version;
+        });
+
         $libraryinfo = array_pop($versions);
         $library = $interface->loadLibrary(
             $libraryinfo->machine_name,

--- a/export_libraries.php
+++ b/export_libraries.php
@@ -103,7 +103,7 @@ send_stored_file($file);
  * @param string $tmppath
  * @param array $exportedlibraries
  */
-function exportlibrary($library, $exporter, $tmppath, &$exportedlibraries) {
+function exportlibrary(array $library, H5PExport $exporter, string $tmppath, array &$exportedlibraries) {
     if (in_array($library['libraryId'], $exportedlibraries)) {
         // Already exported.
         return;
@@ -113,7 +113,6 @@ function exportlibrary($library, $exporter, $tmppath, &$exportedlibraries) {
 
     // Determine path of export library.
     if (isset($exporter->h5pC) && isset($exporter->h5pC->h5pD)) {
-
         // Tries to find library in development folder.
         $isdevlibrary = $exporter->h5pC->h5pD->getLibrary(
             $library['machineName'],
@@ -126,16 +125,40 @@ function exportlibrary($library, $exporter, $tmppath, &$exportedlibraries) {
         }
     }
 
-    // Export library.
-    $exporter->h5pC->fs->exportLibrary($library, $tmppath, $exportfolder);
-    $exportedlibraries[] = $library['libraryId'];
-
-    // Now export the dependancies.
+    // Combine this library and it's dependencies to export, no need to get dependancy
+    // library's dependancies as findlibrarydependencies() is recursive.
     $dependencies = [];
-    $exporter->h5pC->findLibraryDependencies($dependencies, $library);
+    findlibrarydependencies($exporter->h5pC, $dependencies, $library);
+    $libraries = array_merge(
+        [$library],
+        array_column($dependencies, 'library')
+    );
 
-    foreach ($dependencies as $dependency) {
-        exportlibrary($dependency['library'], $exporter, $tmppath, $exportedlibraries);
+    // Export all of the libraries.
+    foreach ($libraries as $library) {
+        if (in_array($library['libraryId'], $exportedlibraries)) {
+            // Exact library has already been exported, move on.
+            continue;
+        }
+
+        // Determine path of export library.
+        $exportfolder = null;
+        if (isset($exporter->h5pC) && isset($exporter->h5pC->h5pD)) {
+            // Tries to find library in development folder.
+            $isdevlibrary = $exporter->h5pC->h5pD->getLibrary(
+                $library['machineName'],
+                $library['majorVersion'],
+                $library['minorVersion']
+            );
+
+            if ($isdevlibrary !== null && isset($library['path'])) {
+                $exportfolder = "/" . $library['path'];
+            }
+        }
+
+        // Export library.
+        $exporter->h5pC->fs->exportLibrary($library, $tmppath, $exportfolder);
+        $exportedlibraries[] = $library['libraryId'];
     }
 }
 
@@ -146,7 +169,7 @@ function exportlibrary($library, $exporter, $tmppath, &$exportedlibraries) {
  * @param array $files
  * @param string $relative
  */
-function populatefilelist($dir, &$files, $relative = '') {
+function populatefilelist(string $dir, array &$files, string $relative = '') {
     $strip = strlen($dir) + 1;
     $contents = glob($dir . '/' . '*');
     if (!empty($contents)) {
@@ -162,4 +185,71 @@ function populatefilelist($dir, &$files, $relative = '') {
             }
         }
     }
+}
+
+/**
+ * This is an edited copy of H5PCore::findLibraryDependencies.
+ * We need this edited function to ensure we get ALL version dependencies and not just
+ * the first version we need as a dependancy like in H5PCore::findLibraryDependencies.
+ *
+ * Example: both Library1 and Library2 have a dependancy for Library3 but different versions of Library3.
+ * In H5PCore we only get the first version we come acorss and miss the other version dependancy.
+ * Library1-1.0
+ *    - Library2-1.0
+ *       -- Library3-1.2
+ *    - Library3-1.0
+ *
+ * Recursive. Goes through the dependency tree for the given library and
+ * adds all the dependencies to the given array in a flat format.
+ *
+ * @param $dependencies
+ * @param array $library To find all dependencies for.
+ * @param int $nextweight An integer determining the order of the libraries
+ *  when they are loaded
+ * @param bool $editor Used internally to force all preloaded sub dependencies
+ *  of an editor dependency to be editor dependencies.
+ * @return int
+ * @see \H5PCore::findLibraryDependencies
+ */
+function findlibrarydependencies(\H5PCore $h5pcore, array &$dependencies, array $library, int $nextweight = 1, bool $editor = false) {
+    foreach (['dynamic', 'preloaded', 'editor'] as $type) {
+        $property = $type . 'Dependencies';
+        if (!isset($library[$property])) {
+            continue; // Skip, no such dependencies.
+        }
+
+        if ($type === 'preloaded' && $editor === true) {
+            // All preloaded dependencies of an editor library is set to editor.
+            $type = 'editor';
+        }
+
+        foreach ($library[$property] as $dependency) {
+            // Include the major and minor version in the key so we also get the correct versions of the dependant library.
+            $dependencykey = $type . '-' . $dependency['machineName'] . '-' . $dependency['majorVersion'] . '.' . $dependency['minorVersion'];
+            if (isset($dependencies[$dependencykey]) === true) {
+                continue; // Skip, already have this.
+            }
+
+            $dependencylibrary = $h5pcore->loadLibrary($dependency['machineName'], $dependency['majorVersion'], $dependency['minorVersion']);
+            if ($dependencylibrary) {
+                $dependencies[$dependencykey] = [
+                    'library' => $dependencylibrary,
+                    'type' => $type,
+                ];
+                $nextweight = findlibrarydependencies($h5pcore, $dependencies, $dependencylibrary, $nextweight, $type === 'editor');
+                $dependencies[$dependencykey]['weight'] = $nextweight++;
+            } else {
+                // This site is missing a dependency!
+                $replacements = [
+                    '@dep' => \H5PCore::libraryToString($dependency),
+                    '@lib' => \H5PCore::libraryToString($library),
+                ];
+                $h5pcore->h5pF->setErrorMessage(
+                    $h5pcore->h5pF->t('Missing dependency @dep required by @lib.', $replacements),
+                    'missing-library-dependency'
+                );
+            }
+        }
+    }
+    return $nextweight;
 }

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024120902;
+$plugin->version   = 2024120903;
 $plugin->requires  = 2022112800; // 4.1.0
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';


### PR DESCRIPTION
This fixes a bunch of issues we've had with the bulk library updater and exporter.

---

- **Issue 1: Some library files contain old json data when bulk exported**
    - When we save a library package we also save an archived zip of that library for quicker access
    - Currently we include patch versions in bulk updates, requiring the library files to be re-written
    - Currently we do not remove and re-save the archived zip
    - Solution: remove the archived zip if it exists when deleting the file tree for a library
    - I have also included an upgrade script to fix any libraries that have most likely been updated in bulk already

---

- **Issue 2: Some library updates get stuck in a loop checking for a missing library**
    - When calling the package validation you can pass a flag to say only update libraries
    - This requires all of the dependent libraries to be in that package, even if that library is already installed in Moodle
    - Some packages (i.e. Branching Question) are incorrect and are missing a required library
    - Solution: do not include the update libraries only flag, this will allow already installed libraries to be included in the package validation. This should be safe still since we only create ad hoc tasks to update libraries knowing they need to be updated.

---

- **Issue 3: Some dependent library versions are not being exported**
    - When we export a library we export all of its dependencies
    - Some libraries could be dependent on a shared library but different versions of it
    - When getting the dependencies with `\H5PCore` it keys them by just the type of dependency and machine name 
    - This means we don't get all of the different versions we need to export
    -  Solution: copy the `\H5PCore::findLibraryDependencies()` function and adjust it so the version is also included in the key so we get all dependent versions of that library

---

- **Issue 4: Some exported libraries have unexpected version exported**
    - Currently we get all libraries and then only use the latest version by popping the end of the version array
    - The function to load all libraries orders by title first before it orders by version
    - Some libraries can contain `(beta)` in the title or any other variation of changed title
    - This messes up the order that we expect to be based on version
    - Solution: re-order the library versions ourselves by purely the version

---

Testing:
- I've tested with my local environment which I have ran numerous library updates on etc.
- I was able to update the Branching Question library without any issues (the latest package version has a missing dependency which led to an infinite loop, tested by setting the patch version to 0 and then running the bulk updater)
- I was able to export my local environment I've been working in and then import that into a fresh Moodle
- There were no missing library errors and the expected highest version of libraries (minus lower version dependencies) were installed