### PR TITLE
fix / h5p#597 catalyst#90 json_decode called with null

### DIFF
--- a/classes/editor_framework.php
+++ b/classes/editor_framework.php
@@ -138,7 +138,8 @@ class editor_framework implements \H5peditorStorage {
                     $library->title = $details->title;
                     $library->runnable = $details->runnable;
                     $library->restricted = $superuser ? false : ($details->restricted === '1' ? true : false);
-                    $library->metadataSettings = json_decode($details->metadata_settings);
+                    $library->metadataSettings =
+                        is_string($details->metadata_settings) ? json_decode($details->metadata_settings) : null;
                     $librarieswithdetails[] = $library;
                 }
             }


### PR DESCRIPTION
The database field is either null or a string. So decode strings and else set null.

Fixes #90.