### PR TITLE
Fix merge conflict

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "library"]
 	path = library
 	url = https://github.com/h5p/h5p-php-library.git
-	branch = stable
+	branch = moodle
 [submodule "editor"]
 	path = editor
 	url = https://github.com/h5p/h5p-editor-php-library.git

--- a/classes/framework.php
+++ b/classes/framework.php
@@ -1513,6 +1513,10 @@ class framework implements \H5PFrameworkInterface {
             'minor_version' => $minorversion
         ));
 
+        if (!$library) {
+            return false;
+        }
+
         $librarydata = array(
             'libraryId' => $library->id,
             'machineName' => $library->machine_name,

--- a/classes/framework.php
+++ b/classes/framework.php
@@ -1917,4 +1917,15 @@ class framework implements \H5PFrameworkInterface {
         global $DB;
         $DB->execute("UPDATE {hvp_content_hub_cache} SET last_checked = ? WHERE language = ?", array($time, $lang));
     }
+
+    /**
+     * @inheritdoc
+     */
+    // @codingStandardsIgnoreLine
+    public function resetHubOrganizationData() {
+        global $DB;
+
+        set_config('hub_secret', '', 'mod_hvp');
+        $DB->execute("UPDATE {hvp} SET hub_id = NULL, synced = NULL, shared = 0");
+    }
 }

--- a/classes/framework.php
+++ b/classes/framework.php
@@ -1570,8 +1570,12 @@ class framework implements \H5PFrameworkInterface {
         $DB->execute("
             UPDATE {hvp}
             SET filtered = null
-            WHERE main_library_id $insql",
-            $inparams
+            WHERE id IN (
+                SELECT DISTINCT cl.hvp_id
+                FROM {hvp_contents_libraries} cl
+                WHERE library_id $insql
+            )",
+          $inparams
         );
     }
 

--- a/classes/framework.php
+++ b/classes/framework.php
@@ -1578,8 +1578,12 @@ class framework implements \H5PFrameworkInterface {
         $DB->execute("
             UPDATE {hvp}
             SET filtered = null
-            WHERE main_library_id $insql",
-            $inparams
+            WHERE id IN (
+                SELECT DISTINCT cl.hvp_id
+                FROM {hvp_contents_libraries} cl
+                WHERE library_id $insql
+            )",
+          $inparams
         );
     }
 
@@ -1928,5 +1932,16 @@ class framework implements \H5PFrameworkInterface {
     public function setContentHubMetadataChecked($time, $lang = 'en') {
         global $DB;
         $DB->execute("UPDATE {hvp_content_hub_cache} SET last_checked = ? WHERE language = ?", array($time, $lang));
+    }
+
+    /**
+     * @inheritdoc
+     */
+    // @codingStandardsIgnoreLine
+    public function resetHubOrganizationData() {
+        global $DB;
+
+        set_config('hub_secret', '', 'mod_hvp');
+        $DB->execute("UPDATE {hvp} SET hub_id = NULL, synced = NULL, shared = 0");
     }
 }

--- a/content_hub_registration.php
+++ b/content_hub_registration.php
@@ -45,6 +45,7 @@ $PAGE->requires->data_for_js('H5PSettings', $settings, true);
 $PAGE->requires->js(new moodle_url('library/js/h5p-hub-registration.js'), true);
 $PAGE->requires->css(new moodle_url('library/styles/h5p.css'));
 $PAGE->requires->css(new moodle_url('library/styles/h5p-hub-registration.css'));
+$PAGE->requires->css(new moodle_url('library/styles/h5p-fonts.css'));
 
 echo $OUTPUT->header();
 

--- a/db/messages.php
+++ b/db/messages.php
@@ -34,7 +34,7 @@ $messageproviders = array(
     'confirmation' => array(
         'capability' => 'mod/hvp:emailconfirmsubmission',
         'defaults' => array(
-            'airnotifier' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_LOGGEDIN + MESSAGE_DEFAULT_LOGGEDOFF,
+            'airnotifier' => MESSAGE_PERMITTED + MESSAGE_DEFAULT_ENABLED,
         ),
     ),
 );

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -567,6 +567,14 @@ function hvp_upgrade_2020112600() {
     }
 }
 
+function hvp_upgrade_2026050600() {
+  global $DB;
+  $DB->execute("
+    UPDATE {hvp}
+    SET filtered = NULL
+  ");
+}
+
 /**
  * Hvp module upgrade function.
  *
@@ -593,6 +601,7 @@ function xmldb_hvp_upgrade($oldversion) {
         2020082800,
         2020091500,
         2020112600,
+        2026050600,
     ];
 
     foreach ($upgrades as $version) {

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -722,6 +722,14 @@ function hvp_upgrade_2024120903() {
     }
 }
 
+function hvp_upgrade_2026050600() {
+  global $DB;
+  $DB->execute("
+    UPDATE {hvp}
+    SET filtered = NULL
+  ");
+}
+
 /**
  * Hvp module upgrade function.
  *
@@ -752,6 +760,7 @@ function xmldb_hvp_upgrade($oldversion) {
         2023122501,
         2024112101,
         2024120903,
+        2026050600,
     ];
 
     foreach ($upgrades as $version) {

--- a/locallib.php
+++ b/locallib.php
@@ -265,6 +265,7 @@ function hvp_admin_add_generic_css_and_js($page, $liburl, $settings = null) {
     $page->requires->data_for_js('H5PAdminIntegration', $settings, true);
     $page->requires->css(new moodle_url($liburl . 'styles/h5p.css' . hvp_get_cache_buster()));
     $page->requires->css(new moodle_url($liburl . 'styles/h5p-admin.css' . hvp_get_cache_buster()));
+    $page->requires->css(new moodle_url($liburl . 'styles/h5p-fonts.css' . hvp_get_cache_buster()));
 
     // Add settings.
     $page->requires->data_for_js('h5p', hvp_get_core_settings(\context_system::instance()), true);

--- a/locallib.php
+++ b/locallib.php
@@ -320,6 +320,7 @@ function hvp_admin_add_generic_css_and_js($page, $settings = null) {
     $page->requires->data_for_js('H5PAdminIntegration', $settings, true);
     $page->requires->css(generate_css_url('/mod/hvp/library/styles/h5p.css'));
     $page->requires->css(generate_css_url('/mod/hvp/library/styles/h5p-admin.css'));
+    $page->requires->css(generate_css_url('/mod/hvp/library/styles/h5p-fonts.css'));
 
     // Add settings.
     $page->requires->data_for_js('h5p', hvp_get_core_settings(\context_system::instance()), true);

--- a/settings.php
+++ b/settings.php
@@ -146,6 +146,7 @@ if ($ADMIN->fulltree) {
         $PAGE->requires->css('/mod/hvp/library/styles/h5p-confirmation-dialog.css');
         $PAGE->requires->css('/mod/hvp/library/styles/h5p.css');
         $PAGE->requires->css('/mod/hvp/library/styles/h5p-core-button.css');
+        $PAGE->requires->css('/mod/hvp/library/styles/h5p-fonts.css');
     }
 
     // Find missing requirements.

--- a/settings.php
+++ b/settings.php
@@ -191,6 +191,7 @@ if ($ADMIN->fulltree) {
         $PAGE->requires->css('/mod/hvp/library/styles/h5p-confirmation-dialog.css');
         $PAGE->requires->css('/mod/hvp/library/styles/h5p.css');
         $PAGE->requires->css('/mod/hvp/library/styles/h5p-core-button.css');
+        $PAGE->requires->css('/mod/hvp/library/styles/h5p-fonts.css');
     }
 
     // Find missing requirements.

--- a/version.php
+++ b/version.php
@@ -23,9 +23,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024091200;
+$plugin->version   = 2024112100;
 $plugin->requires  = 2013051403;
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '1.27.0';
+$plugin->release   = '1.27.1';

--- a/version.php
+++ b/version.php
@@ -23,9 +23,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024112100;
+$plugin->version   = 2024120900;
 $plugin->requires  = 2013051403;
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '1.27.1';
+$plugin->release   = '1.27.2';

--- a/version.php
+++ b/version.php
@@ -23,9 +23,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026012200;
+$plugin->version   = 2026022500;
 $plugin->requires  = 2013051403;
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '1.27.3';
+$plugin->release   = '1.28.0';

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026031900;
+$plugin->version   = 2026050600;
 $plugin->requires  = 2013051403;
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';

--- a/version.php
+++ b/version.php
@@ -23,7 +23,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026022500;
+$plugin->version   = 2026031900;
 $plugin->requires  = 2013051403;
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';

--- a/version.php
+++ b/version.php
@@ -23,9 +23,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024120900;
+$plugin->version   = 2026012200;
 $plugin->requires  = 2013051403;
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '1.27.2';
+$plugin->release   = '1.27.3';

--- a/version.php
+++ b/version.php
@@ -28,4 +28,4 @@ $plugin->requires  = 2013051403;
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '1.28.0';
+$plugin->release   = '1.28.1';

--- a/version.php
+++ b/version.php
@@ -23,10 +23,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024120903;
+$plugin->version   = 2026062500;
 $plugin->requires  = 2022112800; // 4.1.0
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->supported = [401, 404];
-$plugin->release   = '1.27.2';
+$plugin->release   = '1.28.2';

--- a/view.css
+++ b/view.css
@@ -61,13 +61,13 @@
     margin-right: 0.5em;
     font-size: 0.7em;
     line-height: 1;
-    content: "\e917";
-}
-.content-hub-options .content-hub-unshare a:before {
     content: "\e916";
 }
-.content-hub-options .content-hub-sharing:before {
+.content-hub-options .content-hub-unshare a:before {
     content: "\e917";
+}
+.content-hub-options .content-hub-sharing:before {
+    content: "\e916";
     display: inline-block;
     animation: spin 2s linear infinite;
 }


### PR DESCRIPTION
This merge request pulls in recent changes that failed to merge as of https://github.com/h5p/moodle-mod_hvp/tree/a36099fe8c1ac8c5836f42653a55c563b8a05953.

Commands used:
```
git clone -b stable-catalyst git@github.com:catalyst/moodle-mod_hvp.git
cd moodle-mod_hvp
git remote add maintainer git@github.com:h5p/moodle-mod_hvp.git
git fetch maintainer

git checkout -b fix-merge-conflict
git merge --no-edit a36099fe8c1ac8c5836f42653a55c563b8a05953 --no-commit --no-ff
```

Merge conflicts:
```
Auto-merging classes/framework.php
CONFLICT (content): Merge conflict in classes/framework.php
Auto-merging content_hub_registration.php
Auto-merging db/upgrade.php
CONFLICT (content): Merge conflict in db/upgrade.php
Failed to merge submodule library (not checked out)
CONFLICT (submodule): Merge conflict in library
Auto-merging locallib.php
CONFLICT (content): Merge conflict in locallib.php
Auto-merging settings.php
Auto-merging version.php
CONFLICT (content): Merge conflict in version.php
```

What was done:

**CONFLICT (content): Merge conflict in version.php:**
- Bump version to 2026062500
- Bump release to 1.28.2
- Keep all other version.php changes aligned with our fork

**CONFLICT (content): Merge conflict in db/upgrade.php:**
- Keep our version numbers in xmldb_hvp_upgrade method, add upstream code to the end of upgrades (keep both)

**CONFLICT (content): Merge conflict in locallib.php:**
- Follow implementation of c8af158cc59e105303c25f454771d8390abd2592
- Keep current, add $page->requires->css(generate_css_url('/mod/hvp/library/styles/h5p-fonts.css'));

**CONFLICT (content): Merge conflict in classes/framework.php:**
- Follow implementation of 1e76b27a3755f32ce0f092eeb19eaabf4d4a8255
- Keep current
