### PR TITLE
Fix merge conflict

### DIFF
--- a/classes/file_storage.php
+++ b/classes/file_storage.php
@@ -867,11 +867,11 @@ class file_storage implements \H5PFileStorage {
      * @return string Relative path
      */
     // @codingStandardsIgnoreLine
-    public function getUpgradeScript($machinename, $majorversion, $minorversion) {
+    public function getUpgradeScript($library) {
         $context = \context_system::instance();
         $fs = get_file_storage();
         $area = 'libraries';
-        $path = "/{$machinename}-{$majorversion}.{$minorversion}/";
+        $path = '/' . \H5PCore::libraryToFolderName($library) . '/';
         $file = 'upgrades.js';
         if ($fs->get_file($context->id, 'mod_hvp', $area, 0, $path, $file)) {
             return "/{$area}{$path}{$file}";

--- a/classes/results.php
+++ b/classes/results.php
@@ -295,7 +295,12 @@ class results {
         static $ordered;
 
         if (empty($ordered)) {
-            $available = \get_all_user_name_fields();
+            if (class_exists('\core_user\fields')) {
+                $available = \core_user\fields::get_name_fields();
+            } else {
+                $available = \get_all_user_name_fields();
+            }
+
             $displayname = \fullname((object)$available);
             if (empty($displayname)) {
                 $ordered = array("{$prefix}firstname", "{$prefix}lastname");

--- a/locallib.php
+++ b/locallib.php
@@ -577,7 +577,11 @@ function hvp_send_notification_messages($course, $hvp, $attempt, $context, $cm) 
     // Check for notifications required.
     $notifyfields = 'u.id, u.username, u.idnumber, u.email, u.emailstop, u.lang,
             u.timezone, u.mailformat, u.maildisplay, u.auth, u.suspended, u.deleted, ';
-    $notifyfields .= get_all_user_name_fields(true, 'u');
+    if (class_exists('\core_user\fields')) {
+        $notifyfields .= \core_user\fields::for_name()->get_sql('u', false, '', '', false)->selects;
+    } else {
+        $notifyfields .= get_all_user_name_fields(true, 'u');
+    }
     $groups       = groups_get_all_groups($course->id, $submitter->id, $cm->groupingid);
     if (is_array($groups) && count($groups) > 0) {
         $groups = array_keys($groups);

--- a/locallib.php
+++ b/locallib.php
@@ -410,7 +410,7 @@ function hvp_content_upgrade_progress($libraryid) {
  *                to upgrade script
  */
 function hvp_get_library_upgrade_info($name, $major, $minor) {
-    $library = (object) array(
+    $response = (object) array(
         'name' => $name,
         'version' => (object) array(
             'major' => $major,
@@ -419,17 +419,15 @@ function hvp_get_library_upgrade_info($name, $major, $minor) {
     );
 
     $core = \mod_hvp\framework::instance();
-
-    $library->semantics = $core->loadLibrarySemantics($library->name, $library->version->major, $library->version->minor);
-
+    $library = $core->loadLibrary($name, $major, $minor);
     $context = \context_system::instance();
-    $libraryfoldername = "{$library->name}-{$library->version->major}.{$library->version->minor}";
+    $libraryfoldername = \H5PCore::libraryToFolderName($library);
     if (\mod_hvp\file_storage::fileExists($context->id, 'libraries', '/' . $libraryfoldername . '/', 'upgrades.js')) {
         $basepath = \mod_hvp\view_assets::getsiteroot() . '/';
-        $library->upgradesScript = "{$basepath}pluginfile.php/{$context->id}/mod_hvp/libraries/{$libraryfoldername}/upgrades.js";
+        $response->upgradesScript = "{$basepath}pluginfile.php/{$context->id}/mod_hvp/libraries/{$libraryfoldername}/upgrades.js";
     }
 
-    return $library;
+    return $response;
 }
 
 /**

--- a/version.php
+++ b/version.php
@@ -23,9 +23,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026050600;
+$plugin->version   = 2026062500;
 $plugin->requires  = 2013051403;
 $plugin->cron      = 0;
 $plugin->component = 'mod_hvp';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '1.28.1';
+$plugin->release   = '1.28.2';


### PR DESCRIPTION
This merge request pulls in recent changes that failed to merge as of https://github.com/h5p/moodle-mod_hvp/tree/ed65d62a11b90669f8b8316fc5d85f47118721c3.

Commands used:

```
git clone -b stable-catalyst git@github.com:catalyst/moodle-mod_hvp.git moodle-mod_hvp
cd moodle-mod_hvp
git remote add upstream git@github.com:h5p/moodle-mod_hvp.git
git fetch upstream

git checkout -b merge-conflict-fix
git merge --no-edit ed65d62a11b90669f8b8316fc5d85f47118721c3 --no-commit --no-ff
```

Merge conflicts:

```
Auto-merging classes/file_storage.php
Auto-merging classes/results.php
CONFLICT (content): Merge conflict in classes/results.php
Auto-merging locallib.php
CONFLICT (content): Merge conflict in locallib.php
Auto-merging version.php
CONFLICT (content): Merge conflict in version.php
Automatic merge failed; fix conflicts and then commit the result.
```

What was done:

**CONFLICT (content): Merge conflict in version.php:**
- Keep version.php changes aligned with our fork

**CONFLICT (content): Merge conflict in locallib.php:**
- Caused by https://github.com/catalyst/moodle-mod_hvp/commit/4bff85d2a7323ac7867b2043aac3fa0fa9438e4e
- Accept incoming changes, cleaner, and maintains backwards compatibility
<img width="1071" height="636" alt="Screenshot From 2026-07-08 14-18-24" src="https://github.com/user-attachments/assets/ad8ae15f-0e01-4b2d-b3a6-7a84c9634985" />


**CONFLICT (content): Merge conflict in classes/results.php:**
- Caused by https://github.com/catalyst/moodle-mod_hvp/commit/4bff85d2a7323ac7867b2043aac3fa0fa9438e4e
- Accept incoming changes, cleaner, and maintains backwards compatibility
<img width="1310" height="640" alt="Screenshot From 2026-07-08 14-21-55" src="https://github.com/user-attachments/assets/8efa50ea-4d5f-4b16-8121-04ae7ad3debb" />
